### PR TITLE
Add Spotify integration

### DIFF
--- a/Vibify.xcodeproj/project.pbxproj
+++ b/Vibify.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		5A7C664D2B66C06100B43A32 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 5A7C664C2B66C06100B43A32 /* KeychainAccess */; };
 		5A7C66502B68824A00B43A32 /* Color+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C664F2B68824A00B43A32 /* Color+Ext.swift */; };
 		5A7C66522B68887900B43A32 /* Modifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C66512B68887900B43A32 /* Modifiers.swift */; };
+		5A7C66542B6889D000B43A32 /* AlertItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C66532B6889D000B43A32 /* AlertItem.swift */; };
 		5A8979922B3E3944002FEEF6 /* AppleMusicImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8979912B3E3944002FEEF6 /* AppleMusicImporter.swift */; };
 		5A8C28DD2B53116600BD12E6 /* AsyncButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8C28DC2B53116600BD12E6 /* AsyncButton.swift */; };
 		5AA3AC712B5CB09400B3BAC7 /* Array+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA3AC702B5CB09400B3BAC7 /* Array+Ext.swift */; };
@@ -110,6 +111,7 @@
 		5A7C664E2B66C65500B43A32 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5A7C664F2B68824A00B43A32 /* Color+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Ext.swift"; sourceTree = "<group>"; };
 		5A7C66512B68887900B43A32 /* Modifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modifiers.swift; sourceTree = "<group>"; };
+		5A7C66532B6889D000B43A32 /* AlertItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertItem.swift; sourceTree = "<group>"; };
 		5A8979912B3E3944002FEEF6 /* AppleMusicImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMusicImporter.swift; sourceTree = "<group>"; };
 		5A8C28DC2B53116600BD12E6 /* AsyncButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncButton.swift; sourceTree = "<group>"; };
 		5AA3AC702B5CB09400B3BAC7 /* Array+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Ext.swift"; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				5A0158022B3F4BC800048E79 /* Buttonstyles.swift */,
 				5A00475E2B60B2FE00FFD0A6 /* UniqueURL.swift */,
 				5A7C66512B68887900B43A32 /* Modifiers.swift */,
+				5A7C66532B6889D000B43A32 /* AlertItem.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -455,6 +458,7 @@
 				5A8C28DD2B53116600BD12E6 /* AsyncButton.swift in Sources */,
 				5A7C66502B68824A00B43A32 /* Color+Ext.swift in Sources */,
 				5A74305E2B5A0989000FB9BA /* DalleEndpoint.swift in Sources */,
+				5A7C66542B6889D000B43A32 /* AlertItem.swift in Sources */,
 				5A4EC6712B4CF1FF00894E13 /* SharePlaylistButton.swift in Sources */,
 				5A4BFB2B2B4096EF00988D0E /* Date+Ext.swift in Sources */,
 				5A7C664A2B66BC0400B43A32 /* SpotifyService.swift in Sources */,

--- a/Vibify.xcodeproj/project.pbxproj
+++ b/Vibify.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		5A7747AB2B4F761200B26A2D /* DecadePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7747AA2B4F761200B26A2D /* DecadePickerView.swift */; };
 		5A7747AD2B4F764A00B26A2D /* NumberOfSongsCounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7747AC2B4F764A00B26A2D /* NumberOfSongsCounterView.swift */; };
 		5A7C48862B5DBE1D0002A61E /* dalle-sample.png in Resources */ = {isa = PBXBuildFile; fileRef = 5A7C48852B5DBE1D0002A61E /* dalle-sample.png */; };
+		5A7C66472B66BBA400B43A32 /* SpotifyAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 5A7C66462B66BBA400B43A32 /* SpotifyAPI */; };
 		5A8979922B3E3944002FEEF6 /* AppleMusicImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8979912B3E3944002FEEF6 /* AppleMusicImporter.swift */; };
 		5A8C28DD2B53116600BD12E6 /* AsyncButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8C28DC2B53116600BD12E6 /* AsyncButton.swift */; };
 		5AA3AC712B5CB09400B3BAC7 /* Array+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA3AC702B5CB09400B3BAC7 /* Array+Ext.swift */; };
@@ -121,6 +122,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5AC0B7D42B45065C00971FF9 /* GRDB in Frameworks */,
+				5A7C66472B66BBA400B43A32 /* SpotifyAPI in Frameworks */,
 				5A1CAB4E2B4B66570063B102 /* CachedAsyncImage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -301,6 +303,7 @@
 			packageProductDependencies = (
 				5AC0B7D32B45065C00971FF9 /* GRDB */,
 				5A1CAB4D2B4B66570063B102 /* CachedAsyncImage */,
+				5A7C66462B66BBA400B43A32 /* SpotifyAPI */,
 			);
 			productName = Vibify;
 			productReference = 5A1CD9722B3D1CA200AF0192 /* Vibify.app */;
@@ -333,6 +336,7 @@
 			packageReferences = (
 				5AC0B7D22B45065C00971FF9 /* XCRemoteSwiftPackageReference "GRDB.swift" */,
 				5A1CAB4C2B4B66570063B102 /* XCRemoteSwiftPackageReference "CachedAsyncImage" */,
+				5A7C66452B66BBA300B43A32 /* XCRemoteSwiftPackageReference "SpotifyAPI" */,
 			);
 			productRefGroup = 5A1CD9732B3D1CA200AF0192 /* Products */;
 			projectDirPath = "";
@@ -646,6 +650,14 @@
 				kind = branch;
 			};
 		};
+		5A7C66452B66BBA300B43A32 /* XCRemoteSwiftPackageReference "SpotifyAPI" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Peter-Schorn/SpotifyAPI";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.2.4;
+			};
+		};
 		5AC0B7D22B45065C00971FF9 /* XCRemoteSwiftPackageReference "GRDB.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/groue/GRDB.swift.git";
@@ -661,6 +673,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5A1CAB4C2B4B66570063B102 /* XCRemoteSwiftPackageReference "CachedAsyncImage" */;
 			productName = CachedAsyncImage;
+		};
+		5A7C66462B66BBA400B43A32 /* SpotifyAPI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5A7C66452B66BBA300B43A32 /* XCRemoteSwiftPackageReference "SpotifyAPI" */;
+			productName = SpotifyAPI;
 		};
 		5AC0B7D32B45065C00971FF9 /* GRDB */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Vibify.xcodeproj/project.pbxproj
+++ b/Vibify.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		5A7C66472B66BBA400B43A32 /* SpotifyAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 5A7C66462B66BBA400B43A32 /* SpotifyAPI */; };
 		5A7C664A2B66BC0400B43A32 /* SpotifyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C66492B66BC0400B43A32 /* SpotifyService.swift */; };
 		5A7C664D2B66C06100B43A32 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 5A7C664C2B66C06100B43A32 /* KeychainAccess */; };
+		5A7C66502B68824A00B43A32 /* Color+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C664F2B68824A00B43A32 /* Color+Ext.swift */; };
+		5A7C66522B68887900B43A32 /* Modifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C66512B68887900B43A32 /* Modifiers.swift */; };
 		5A8979922B3E3944002FEEF6 /* AppleMusicImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8979912B3E3944002FEEF6 /* AppleMusicImporter.swift */; };
 		5A8C28DD2B53116600BD12E6 /* AsyncButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8C28DC2B53116600BD12E6 /* AsyncButton.swift */; };
 		5AA3AC712B5CB09400B3BAC7 /* Array+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA3AC702B5CB09400B3BAC7 /* Array+Ext.swift */; };
@@ -106,6 +108,8 @@
 		5A7C48852B5DBE1D0002A61E /* dalle-sample.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "dalle-sample.png"; sourceTree = "<group>"; };
 		5A7C66492B66BC0400B43A32 /* SpotifyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyService.swift; sourceTree = "<group>"; };
 		5A7C664E2B66C65500B43A32 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		5A7C664F2B68824A00B43A32 /* Color+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Ext.swift"; sourceTree = "<group>"; };
+		5A7C66512B68887900B43A32 /* Modifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modifiers.swift; sourceTree = "<group>"; };
 		5A8979912B3E3944002FEEF6 /* AppleMusicImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMusicImporter.swift; sourceTree = "<group>"; };
 		5A8C28DC2B53116600BD12E6 /* AsyncButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncButton.swift; sourceTree = "<group>"; };
 		5AA3AC702B5CB09400B3BAC7 /* Array+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Ext.swift"; sourceTree = "<group>"; };
@@ -195,6 +199,7 @@
 				5A4BFB2A2B4096EF00988D0E /* Date+Ext.swift */,
 				5AD5A4B02B408BE7005FC577 /* String+Ext.swift */,
 				5AA3AC702B5CB09400B3BAC7 /* Array+Ext.swift */,
+				5A7C664F2B68824A00B43A32 /* Color+Ext.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -204,6 +209,7 @@
 			children = (
 				5A0158022B3F4BC800048E79 /* Buttonstyles.swift */,
 				5A00475E2B60B2FE00FFD0A6 /* UniqueURL.swift */,
+				5A7C66512B68887900B43A32 /* Modifiers.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -427,6 +433,7 @@
 				5AE3F6602B4E520900EA8329 /* AdvancedSearchCriteriaVM.swift in Sources */,
 				5A1CD9762B3D1CA200AF0192 /* VibifyApp.swift in Sources */,
 				5A201B5C2B61E5D600527EA0 /* ServiceStatusView.swift in Sources */,
+				5A7C66522B68887900B43A32 /* Modifiers.swift in Sources */,
 				5A4903392B60A475005688B6 /* PlaylistRowView.swift in Sources */,
 				5A0DCA1A2B4860E3007A0B72 /* Double+Ext.swift in Sources */,
 				5AA5E5D42B5C2B570048FE2F /* GPTRequest.swift in Sources */,
@@ -446,6 +453,7 @@
 				5A4523742B3FCC530026494C /* SongCardView.swift in Sources */,
 				5A0D89582B45160E003420A8 /* PlaylistHistoryView.swift in Sources */,
 				5A8C28DD2B53116600BD12E6 /* AsyncButton.swift in Sources */,
+				5A7C66502B68824A00B43A32 /* Color+Ext.swift in Sources */,
 				5A74305E2B5A0989000FB9BA /* DalleEndpoint.swift in Sources */,
 				5A4EC6712B4CF1FF00894E13 /* SharePlaylistButton.swift in Sources */,
 				5A4BFB2B2B4096EF00988D0E /* Date+Ext.swift in Sources */,

--- a/Vibify.xcodeproj/project.pbxproj
+++ b/Vibify.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		5A7747AD2B4F764A00B26A2D /* NumberOfSongsCounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7747AC2B4F764A00B26A2D /* NumberOfSongsCounterView.swift */; };
 		5A7C48862B5DBE1D0002A61E /* dalle-sample.png in Resources */ = {isa = PBXBuildFile; fileRef = 5A7C48852B5DBE1D0002A61E /* dalle-sample.png */; };
 		5A7C66472B66BBA400B43A32 /* SpotifyAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 5A7C66462B66BBA400B43A32 /* SpotifyAPI */; };
+		5A7C664A2B66BC0400B43A32 /* SpotifyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C66492B66BC0400B43A32 /* SpotifyService.swift */; };
+		5A7C664D2B66C06100B43A32 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 5A7C664C2B66C06100B43A32 /* KeychainAccess */; };
 		5A8979922B3E3944002FEEF6 /* AppleMusicImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8979912B3E3944002FEEF6 /* AppleMusicImporter.swift */; };
 		5A8C28DD2B53116600BD12E6 /* AsyncButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8C28DC2B53116600BD12E6 /* AsyncButton.swift */; };
 		5AA3AC712B5CB09400B3BAC7 /* Array+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA3AC702B5CB09400B3BAC7 /* Array+Ext.swift */; };
@@ -102,6 +104,7 @@
 		5A7747AA2B4F761200B26A2D /* DecadePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecadePickerView.swift; sourceTree = "<group>"; };
 		5A7747AC2B4F764A00B26A2D /* NumberOfSongsCounterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberOfSongsCounterView.swift; sourceTree = "<group>"; };
 		5A7C48852B5DBE1D0002A61E /* dalle-sample.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "dalle-sample.png"; sourceTree = "<group>"; };
+		5A7C66492B66BC0400B43A32 /* SpotifyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyService.swift; sourceTree = "<group>"; };
 		5A8979912B3E3944002FEEF6 /* AppleMusicImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMusicImporter.swift; sourceTree = "<group>"; };
 		5A8C28DC2B53116600BD12E6 /* AsyncButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncButton.swift; sourceTree = "<group>"; };
 		5AA3AC702B5CB09400B3BAC7 /* Array+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Ext.swift"; sourceTree = "<group>"; };
@@ -121,6 +124,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A7C664D2B66C06100B43A32 /* KeychainAccess in Frameworks */,
 				5AC0B7D42B45065C00971FF9 /* GRDB in Frameworks */,
 				5A7C66472B66BBA400B43A32 /* SpotifyAPI in Frameworks */,
 				5A1CAB4E2B4B66570063B102 /* CachedAsyncImage in Frameworks */,
@@ -256,11 +260,20 @@
 			children = (
 				5A74305B2B5A093F000FB9BA /* Endpoint.swift */,
 				5A7430592B5A00AE000FB9BA /* URLSessionNetworkService.swift */,
+				5A7C66482B66BBF300B43A32 /* Spotify */,
 				5A0047642B61DE9800FFD0A6 /* ServiceStatus */,
 				5AA5E5D02B5C2B070048FE2F /* Dalle */,
 				5AA5E5CF2B5C2AFE0048FE2F /* GPT */,
 			);
 			path = API;
+			sourceTree = "<group>";
+		};
+		5A7C66482B66BBF300B43A32 /* Spotify */ = {
+			isa = PBXGroup;
+			children = (
+				5A7C66492B66BC0400B43A32 /* SpotifyService.swift */,
+			);
+			path = Spotify;
 			sourceTree = "<group>";
 		};
 		5AA5E5CF2B5C2AFE0048FE2F /* GPT */ = {
@@ -304,6 +317,7 @@
 				5AC0B7D32B45065C00971FF9 /* GRDB */,
 				5A1CAB4D2B4B66570063B102 /* CachedAsyncImage */,
 				5A7C66462B66BBA400B43A32 /* SpotifyAPI */,
+				5A7C664C2B66C06100B43A32 /* KeychainAccess */,
 			);
 			productName = Vibify;
 			productReference = 5A1CD9722B3D1CA200AF0192 /* Vibify.app */;
@@ -337,6 +351,7 @@
 				5AC0B7D22B45065C00971FF9 /* XCRemoteSwiftPackageReference "GRDB.swift" */,
 				5A1CAB4C2B4B66570063B102 /* XCRemoteSwiftPackageReference "CachedAsyncImage" */,
 				5A7C66452B66BBA300B43A32 /* XCRemoteSwiftPackageReference "SpotifyAPI" */,
+				5A7C664B2B66C06100B43A32 /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 			);
 			productRefGroup = 5A1CD9732B3D1CA200AF0192 /* Products */;
 			projectDirPath = "";
@@ -432,6 +447,7 @@
 				5A74305E2B5A0989000FB9BA /* DalleEndpoint.swift in Sources */,
 				5A4EC6712B4CF1FF00894E13 /* SharePlaylistButton.swift in Sources */,
 				5A4BFB2B2B4096EF00988D0E /* Date+Ext.swift in Sources */,
+				5A7C664A2B66BC0400B43A32 /* SpotifyService.swift in Sources */,
 				5AB8FC3B2B4332EE008AC7C4 /* SongSearchCriteria.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -658,6 +674,14 @@
 				minimumVersion = 2.2.4;
 			};
 		};
+		5A7C664B2B66C06100B43A32 /* XCRemoteSwiftPackageReference "KeychainAccess" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kishikawakatsumi/KeychainAccess";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		5AC0B7D22B45065C00971FF9 /* XCRemoteSwiftPackageReference "GRDB.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/groue/GRDB.swift.git";
@@ -678,6 +702,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5A7C66452B66BBA300B43A32 /* XCRemoteSwiftPackageReference "SpotifyAPI" */;
 			productName = SpotifyAPI;
+		};
+		5A7C664C2B66C06100B43A32 /* KeychainAccess */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5A7C664B2B66C06100B43A32 /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+			productName = KeychainAccess;
 		};
 		5AC0B7D32B45065C00971FF9 /* GRDB */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Vibify.xcodeproj/project.pbxproj
+++ b/Vibify.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		5A7747AC2B4F764A00B26A2D /* NumberOfSongsCounterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberOfSongsCounterView.swift; sourceTree = "<group>"; };
 		5A7C48852B5DBE1D0002A61E /* dalle-sample.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "dalle-sample.png"; sourceTree = "<group>"; };
 		5A7C66492B66BC0400B43A32 /* SpotifyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyService.swift; sourceTree = "<group>"; };
+		5A7C664E2B66C65500B43A32 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5A8979912B3E3944002FEEF6 /* AppleMusicImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMusicImporter.swift; sourceTree = "<group>"; };
 		5A8C28DC2B53116600BD12E6 /* AsyncButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncButton.swift; sourceTree = "<group>"; };
 		5AA3AC702B5CB09400B3BAC7 /* Array+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Ext.swift"; sourceTree = "<group>"; };
@@ -226,6 +227,7 @@
 		5A1CD9742B3D1CA200AF0192 /* Vibify */ = {
 			isa = PBXGroup;
 			children = (
+				5A7C664E2B66C65500B43A32 /* Info.plist */,
 				5A1CD9752B3D1CA200AF0192 /* VibifyApp.swift */,
 				5A0047622B60B57A00FFD0A6 /* DatabaseManaging.swift */,
 				5AC0B7D72B4506EA00971FF9 /* DatabaseManager.swift */,
@@ -584,6 +586,7 @@
 				DEVELOPMENT_TEAM = P4DQK6SRKR;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Vibify/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "We need access to your Apple Music account to add new playlists";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -614,6 +617,7 @@
 				DEVELOPMENT_TEAM = P4DQK6SRKR;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Vibify/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "We need access to your Apple Music account to add new playlists";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Vibify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vibify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -17,6 +17,51 @@
         "branch" : "master",
         "revision" : "d1ff0912f184f92103985e31ed9f99babf6dea9e"
       }
+    },
+    {
+      "identity" : "opencombine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/OpenCombine/OpenCombine.git",
+      "state" : {
+        "revision" : "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
+        "version" : "0.14.0"
+      }
+    },
+    {
+      "identity" : "regularexpressions",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Peter-Schorn/RegularExpressions.git",
+      "state" : {
+        "revision" : "b27140d0bd3a9a1e61f2324f644219be98eb3311",
+        "version" : "2.2.0"
+      }
+    },
+    {
+      "identity" : "spotifyapi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Peter-Schorn/SpotifyAPI",
+      "state" : {
+        "revision" : "74c3e42ebd983ecf3ceaef65786c72f971495003",
+        "version" : "2.2.4"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+        "version" : "1.1.7"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+        "version" : "1.5.4"
+      }
     }
   ],
   "version" : 2

--- a/Vibify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vibify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "keychainaccess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kishikawakatsumi/KeychainAccess",
+      "state" : {
+        "branch" : "master",
+        "revision" : "e0c7eebc5a4465a3c4680764f26b7a61f567cdaf"
+      }
+    },
+    {
       "identity" : "opencombine",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OpenCombine/OpenCombine.git",

--- a/Vibify/API/Spotify/SpotifyService.swift
+++ b/Vibify/API/Spotify/SpotifyService.swift
@@ -2,6 +2,7 @@ import Combine
 import Foundation
 import KeychainAccess
 import SpotifyWebAPI
+import SwiftUI
 
 @Observable final class SpotifyService {
     
@@ -73,23 +74,41 @@ import SpotifyWebAPI
         }
     }()
     
+    var authorizationURL: URL {
+        let url = api.authorizationManager.makeAuthorizationURL(
+            redirectURI: loginCallbackURL,
+            showDialog: true,
+            state: authorizationState,
+            scopes: [
+                .userReadPlaybackState,
+                .userModifyPlaybackState,
+                .playlistModifyPrivate,
+                .playlistModifyPublic,
+                .userLibraryRead,
+                .userLibraryModify,
+                .userReadRecentlyPlayed
+            ]
+        )!
+        
+        return url
+    }
+
+    
     func authorizationManagerDidChange() {
         
-        //        withAnimation(LoginView.animation) {
-        //            isAuthorized = api.authorizationManager.isAuthorized()
-        //        }
+        withAnimation() {
+            isAuthorized = api.authorizationManager.isAuthorized()
+        }
         
         debugPrint("Spotify.authorizationManagerDidChange: isAuthorized:", isAuthorized)
         
         self.retrieveCurrentUser()
         
         do {
-            // Encode the authorization information to data.
             let authManagerData = try JSONEncoder().encode(
                 api.authorizationManager
             )
             
-            // Save the data to the keychain.
             keychain[data: authorizationManagerKey] = authManagerData
             print("did save authorization manager to keychain")
             
@@ -105,9 +124,9 @@ import SpotifyWebAPI
     /// Removes `api.authorizationManager` from the keychain and sets `currentUser` to `nil`. This method is called every time `api.authorizationManager.deauthorize` is called.
     func authorizationManagerDidDeauthorize() {
         
-        //        withAnimation(LoginView.animation) {
-        //            self.isAuthorized = false
-        //        }
+        withAnimation() {
+            isAuthorized = false
+        }
         
         currentUser = nil
         

--- a/Vibify/API/Spotify/SpotifyService.swift
+++ b/Vibify/API/Spotify/SpotifyService.swift
@@ -1,0 +1,164 @@
+import Combine
+import Foundation
+import KeychainAccess
+import SpotifyWebAPI
+
+@Observable final class SpotifyService {
+    
+    /// The authorization key stored in the Keychain
+    let authorizationManagerKey = "authorizationManager"
+    
+    /// The URL that Spotify will redirect to after the user either authorizes or denies authorization.
+    let loginCallbackURL = URL(string: "vibify://spotify-login-callback")!
+    
+    /// A cryptographically secure random string used to prevent CSRF attacks.
+    var authorizationState: String = {
+        String.randomURLSafe(length: 128)
+    }()
+    
+    /// Checks whether the user is authorized to use the Spotify API.
+    var isAuthorized = false
+    
+    /// Checks if the user is retrieving access and refresh tokens.
+    var isRetrievingTokens = false
+    
+    /// The current Spotify user.
+    var currentUser: SpotifyUser? = nil
+    
+    private(set) var keychain = Keychain(service: "com.marcusziade.Vibify.app")
+    
+    /// An instance of the Spotify API.
+    let api = SpotifyAPI(
+        authorizationManager: AuthorizationCodeFlowManager(
+            clientId: clientID,
+            clientSecret: clientSecret
+        )
+    )
+    
+    init() {
+        api.apiRequestLogger.logLevel = .trace
+        
+        api.authorizationManagerDidChange
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: authorizationManagerDidChange)
+            .store(in: &cancellables)
+        
+        api.authorizationManagerDidDeauthorize
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: authorizationManagerDidDeauthorize)
+            .store(in: &cancellables)
+        
+        retrieveTokensFromKeychainIfNeeded()
+        
+        
+    }
+    
+    // MARK: Private
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    private static let clientID: String = {
+        if let id = ProcessInfo.processInfo.environment["SPOTIFY_CLIENT_ID"] {
+            return id
+        } else {
+            fatalError("SPOTIFY_CLIENT_ID not set")
+        }
+    }()
+    
+    private static let clientSecret: String = {
+        if let secret = ProcessInfo.processInfo.environment["SPOTIFY_CLIENT_SECRET"] {
+            return secret
+        } else {
+            fatalError("SPOTIFY_CLIENT_SECRET not set")
+        }
+    }()
+    
+    func authorizationManagerDidChange() {
+        
+        //        withAnimation(LoginView.animation) {
+        //            isAuthorized = api.authorizationManager.isAuthorized()
+        //        }
+        
+        debugPrint("Spotify.authorizationManagerDidChange: isAuthorized:", isAuthorized)
+        
+        self.retrieveCurrentUser()
+        
+        do {
+            // Encode the authorization information to data.
+            let authManagerData = try JSONEncoder().encode(
+                api.authorizationManager
+            )
+            
+            // Save the data to the keychain.
+            keychain[data: authorizationManagerKey] = authManagerData
+            print("did save authorization manager to keychain")
+            
+        } catch {
+            print(
+                "couldn't encode authorizationManager for storage " +
+                "in keychain:\n\(error)"
+            )
+        }
+        
+    }
+    
+    /// Removes `api.authorizationManager` from the keychain and sets `currentUser` to `nil`. This method is called every time `api.authorizationManager.deauthorize` is called.
+    func authorizationManagerDidDeauthorize() {
+        
+        //        withAnimation(LoginView.animation) {
+        //            self.isAuthorized = false
+        //        }
+        
+        currentUser = nil
+        
+        do {
+            try self.keychain.remove(self.authorizationManagerKey)
+            print("did remove authorization manager from keychain")
+            
+        } catch {
+            print(
+                "couldn't remove authorization manager " +
+                "from keychain: \(error)"
+            )
+        }
+    }
+    
+    func retrieveCurrentUser(onlyIfNil: Bool = true) {
+        if onlyIfNil && self.currentUser != nil {
+            return
+        }
+        
+        guard isAuthorized else { return }
+        
+        api.currentUserProfile()
+            .receive(on: RunLoop.main)
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        print("couldn't retrieve current user: \(error)")
+                    }
+                },
+                receiveValue: { [unowned self] user in
+                    currentUser = user
+                }
+            )
+            .store(in: &cancellables)
+    }
+    
+    private func retrieveTokensFromKeychainIfNeeded() {
+        if let authManagerData = keychain[data: self.authorizationManagerKey] {
+            do {
+                let authorizationManager = try JSONDecoder().decode(
+                    AuthorizationCodeFlowManager.self,
+                    from: authManagerData
+                )
+                print("found authorization information in keychain")
+                api.authorizationManager = authorizationManager
+            } catch {
+                print("could not decode authorizationManager from data:\n\(error)")
+            }
+        } else {
+            print("did NOT find authorization information in keychain")
+        }
+    }
+}

--- a/Vibify/API/Spotify/SpotifyService.swift
+++ b/Vibify/API/Spotify/SpotifyService.swift
@@ -36,6 +36,25 @@ import SwiftUI
         )
     )
     
+    var authorizationURL: URL {
+        let url = api.authorizationManager.makeAuthorizationURL(
+            redirectURI: loginCallbackURL,
+            showDialog: true,
+            state: authorizationState,
+            scopes: [
+                .userReadPlaybackState,
+                .userModifyPlaybackState,
+                .playlistModifyPrivate,
+                .playlistModifyPublic,
+                .userLibraryRead,
+                .userLibraryModify,
+                .userReadRecentlyPlayed
+            ]
+        )!
+        
+        return url
+    }
+    
     init() {
         api.apiRequestLogger.logLevel = .trace
         
@@ -50,8 +69,6 @@ import SwiftUI
             .store(in: &cancellables)
         
         retrieveTokensFromKeychainIfNeeded()
-        
-        
     }
     
     // MARK: Private
@@ -74,28 +91,7 @@ import SwiftUI
         }
     }()
     
-    var authorizationURL: URL {
-        let url = api.authorizationManager.makeAuthorizationURL(
-            redirectURI: loginCallbackURL,
-            showDialog: true,
-            state: authorizationState,
-            scopes: [
-                .userReadPlaybackState,
-                .userModifyPlaybackState,
-                .playlistModifyPrivate,
-                .playlistModifyPublic,
-                .userLibraryRead,
-                .userLibraryModify,
-                .userReadRecentlyPlayed
-            ]
-        )!
-        
-        return url
-    }
-
-    
     func authorizationManagerDidChange() {
-        
         withAnimation() {
             isAuthorized = api.authorizationManager.isAuthorized()
         }
@@ -118,12 +114,10 @@ import SwiftUI
                 "in keychain:\n\(error)"
             )
         }
-        
     }
     
     /// Removes `api.authorizationManager` from the keychain and sets `currentUser` to `nil`. This method is called every time `api.authorizationManager.deauthorize` is called.
     func authorizationManagerDidDeauthorize() {
-        
         withAnimation() {
             isAuthorized = false
         }

--- a/Vibify/Components/AlertItem.swift
+++ b/Vibify/Components/AlertItem.swift
@@ -1,0 +1,20 @@
+import Foundation
+import SwiftUI
+
+struct AlertItem: Identifiable {
+    
+    let id = UUID()
+    let title: Text
+    let message: Text
+    
+    init(title: String, message: String) {
+        self.title = Text(title)
+        self.message = Text(message)
+    }
+    
+    init(title: Text, message: Text) {
+        self.title = title
+        self.message = message
+    }
+    
+}

--- a/Vibify/Components/Modifiers.swift
+++ b/Vibify/Components/Modifiers.swift
@@ -1,0 +1,18 @@
+import Foundation
+import SwiftUI
+
+struct AsyncButtonModifier: ViewModifier {
+    
+    let colors: [Color]
+    
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: .infinity)
+            .font(.headline)
+            .foregroundColor(.white)
+            .padding()
+            .background(LinearGradient(colors: colors, startPoint: .bottom, endPoint: .top))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .padding(.horizontal)
+    }
+}

--- a/Vibify/Extensions/Color+Ext.swift
+++ b/Vibify/Extensions/Color+Ext.swift
@@ -1,0 +1,11 @@
+import Foundation
+import SwiftUI
+
+// MARK: Common color extensions
+
+extension Color {
+    
+    static var darkGreen: Color {
+        Color(red: 0.0, green: 0.6, blue: 0.0)
+    }
+}

--- a/Vibify/Info.plist
+++ b/Vibify/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
+        <key>LSApplicationQueriesSchemes</key>
+        <string>spotify</string>
         <key>CFBundleURLTypes</key>
         <array>
             <dict>

--- a/Vibify/Info.plist
+++ b/Vibify/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>CFBundleURLTypes</key>
+        <array>
+            <dict>
+                <key>CFBundleURLName</key>
+                <string>com.marcusz.vibify</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>vibify</string>
+                </array>
+            </dict>
+        </array>
+    </dict>
+</plist>

--- a/Vibify/Screens/PlaylistGeneratorView.swift
+++ b/Vibify/Screens/PlaylistGeneratorView.swift
@@ -179,28 +179,18 @@ private extension PlaylistGeneratorView {
                 AsyncButton(
                     title: "Add to Spotify",
                     icon: "music.note.list",
-                    action: {},// viewModel.createAndAddPlaylistToSpotify,
-                    isLoading: $viewModel.isAddingToAppleMusic,
-                    colors: [.green, darkGreen],
+                    action: {},//viewModel.createAndAddPlaylistToSpotify,
+                    isLoading: .constant(false),//$viewModel.isAddingToSpotify,
+                    colors: [.green, .darkGreen],
                     progress: $viewModel.progress
                 )
             } else if !viewModel.playlistSuggestion.isEmpty && !spotifyService.isAuthorized {
                 Link(destination: spotifyService.authorizationURL, label: {
                     Text("Connect Spotify")
-                        .font(.headline)
-                        .foregroundColor(.white)
-                        .padding()
-                        .background(Color.green)
-                        .cornerRadius(8)
-                        .shadow(color: .secondary, radius: 8)
-                        .padding()
+                        .modifier(AsyncButtonModifier(colors: [.green, .darkGreen]))
                 })
             }
         }
-    }
-    
-    var darkGreen: Color {
-        Color(red: 0.0, green: 0.6, blue: 0.0)
     }
     
     var sharePlaylistButton: some View {

--- a/Vibify/Screens/PlaylistGeneratorView.swift
+++ b/Vibify/Screens/PlaylistGeneratorView.swift
@@ -2,6 +2,9 @@ import CachedAsyncImage
 import SwiftUI
 
 struct PlaylistGeneratorView: View {
+    
+    @Environment(SpotifyService.self) var spotifyService
+    
     @Bindable var viewModel: PlaylistGeneratorVM
     @Bindable private var advancedSearchVM = AdvancedSearchCriteriaVM()
     
@@ -172,7 +175,7 @@ private extension PlaylistGeneratorView {
     
     var addToSpotifyButton: some View {
         Group {
-            if !viewModel.playlistSuggestion.isEmpty { // && viewModel.isAuthorizedForSpotify {
+            if !viewModel.playlistSuggestion.isEmpty && spotifyService.isAuthorized {
                 AsyncButton(
                     title: "Add to Spotify",
                     icon: "music.note.list",
@@ -181,6 +184,17 @@ private extension PlaylistGeneratorView {
                     colors: [.green, darkGreen],
                     progress: $viewModel.progress
                 )
+            } else if !viewModel.playlistSuggestion.isEmpty && !spotifyService.isAuthorized {
+                Link(destination: spotifyService.authorizationURL, label: {
+                    Text("Connect Spotify")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .padding()
+                        .background(Color.green)
+                        .cornerRadius(8)
+                        .shadow(color: .secondary, radius: 8)
+                        .padding()
+                })
             }
         }
     }

--- a/Vibify/VibifyApp.swift
+++ b/Vibify/VibifyApp.swift
@@ -1,11 +1,20 @@
+import SpotifyWebAPI
 import SwiftUI
 
 @main
 struct VibifyApp: App {
     
+    @State private var spotify = SpotifyService()
+    
+    init() {
+        SpotifyAPILogHandler.bootstrap()
+    }
+    
     var body: some Scene {
         WindowGroup {
+#warning("Replace this with a root view.")
             PlaylistGeneratorView(viewModel: initialize())
+                .environment(spotify)
         }
     }
     

--- a/Vibify/VibifyApp.swift
+++ b/Vibify/VibifyApp.swift
@@ -1,3 +1,4 @@
+import Combine
 import SpotifyWebAPI
 import SwiftUI
 
@@ -5,6 +6,8 @@ import SwiftUI
 struct VibifyApp: App {
     
     @State private var spotify = SpotifyService()
+    @State private var alert: AlertItem? = nil
+    @State private var cancellables: Set<AnyCancellable> = []
     
     init() {
         SpotifyAPILogHandler.bootstrap()
@@ -15,8 +18,15 @@ struct VibifyApp: App {
 #warning("Replace this with a root view.")
             PlaylistGeneratorView(viewModel: initialize())
                 .environment(spotify)
+                .alert(item: $alert) { alert in
+                    Alert(title: alert.title, message: alert.message)
+                }
+                .onOpenURL(perform: handleURL)
         }
     }
+}
+
+private extension VibifyApp {
     
     func initialize() -> PlaylistGeneratorVM {
         let networkService = URLSessionNetworkService()
@@ -28,5 +38,60 @@ struct VibifyApp: App {
             dalleGenerator: DalleGenerator(networkService: networkService)
         )
         return playlistGenerator
+    }
+    
+    /// Handle the URL that Spotify redirects to after the user Either authorizes or denies authorization for the application.
+    /// This method is called by the `onOpenURL(perform:)` view modifier directly above.
+    /// - Warning: The simulator crashes with this.
+    /// - Note: Arc Browse browser (released 2024) doesn't support callback URLs.
+    func handleURL(_ url: URL) {
+        guard url.scheme == spotify.loginCallbackURL.scheme else {
+            print("not handling URL: unexpected scheme: '\(url)'")
+            alert = AlertItem(
+                title: "Cannot Handle Redirect",
+                message: "Unexpected URL"
+            )
+            return
+        }
+        
+        print("received redirect from Spotify: '\(url)'")
+        
+        spotify.isRetrievingTokens = true
+        
+        spotify.api.authorizationManager.requestAccessAndRefreshTokens(
+            redirectURIWithQuery: url,
+            state: spotify.authorizationState
+        )
+        .receive(on: RunLoop.main)
+        .sink(receiveCompletion: { completion in
+            spotify.isRetrievingTokens = false
+            
+            if case .failure(let error) = completion {
+                print("couldn't retrieve access and refresh tokens:\n\(error)")
+                let alertTitle: String
+                let alertMessage: String
+                if let authError = error as? SpotifyAuthorizationError,
+                   authError.accessWasDenied {
+                    alertTitle = "You Denied The Authorization Request :("
+                    alertMessage = ""
+                }
+                else {
+                    alertTitle =
+                    "Couldn't Authorization With Your Account"
+                    alertMessage = error.localizedDescription
+                }
+                alert = AlertItem(
+                    title: alertTitle, message: alertMessage
+                )
+            }
+        })
+        .store(in: &cancellables)
+        
+        /// IMPORTANT: generate a new value for the state parameter after
+        /// each authorization request. This ensures an incoming redirect
+        /// from Spotify was the result of a request made by this app, and
+        /// and not an attacker.
+        spotify.authorizationState = String.randomURLSafe(length: 128)
+        
     }
 }

--- a/Vibify/VibifyApp.swift
+++ b/Vibify/VibifyApp.swift
@@ -41,7 +41,6 @@ private extension VibifyApp {
     }
     
     /// Handle the URL that Spotify redirects to after the user Either authorizes or denies authorization for the application.
-    /// This method is called by the `onOpenURL(perform:)` view modifier directly above.
     /// - Warning: The simulator crashes with this.
     /// - Note: Arc Browse browser (released 2024) doesn't support callback URLs.
     func handleURL(_ url: URL) {

--- a/Vibify/Views/AsyncButton.swift
+++ b/Vibify/Views/AsyncButton.swift
@@ -8,6 +8,7 @@ struct AsyncButton: View {
     @Binding var isLoading: Bool
     let colors: [Color]
     @Binding var progress: Double
+    var showLoadingBar: Bool = true
     
     var body: some View {
         Button {
@@ -18,25 +19,35 @@ struct AsyncButton: View {
             }
         } label: {
             if isLoading {
-                CustomProgressView(progress: Binding.constant(progress), title: title)
-                    .frame(maxWidth: .infinity)
-                    .background(LinearGradient(colors: colors, startPoint: .bottom, endPoint: .top))
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .padding(.horizontal)
+                CustomProgressView(
+                    progress: $progress,
+                    title: title,
+                    showLoadingBar: showLoadingBar
+                )
             } else {
                 Label(title, systemImage: icon)
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .padding()
-                    .frame(maxWidth: .infinity)
-                    .background(LinearGradient(colors: colors, startPoint: .bottom, endPoint: .top))
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .padding(.horizontal)
             }
         }
+        .buttonStyle(AsyncButtonStyle(colors: colors))
         .disabled(isLoading)
     }
 }
+
+struct AsyncButtonStyle: ButtonStyle {
+    let colors: [Color]
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(maxWidth: .infinity)
+            .font(.headline)
+            .foregroundColor(.white)
+            .padding()
+            .background(LinearGradient(colors: colors, startPoint: .bottom, endPoint: .top))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .padding(.horizontal)
+    }
+}
+
 #Preview {
     VStack {
         AsyncButton(
@@ -44,7 +55,15 @@ struct AsyncButton: View {
             icon: "person",
             action: { },
             isLoading: .constant(false),
-            colors: [.purple, .pink], 
+            colors: [.purple, .pink],
+            progress: .constant(.zero)
+        )
+        AsyncButton(
+            title: "Add to Spotify",
+            icon: "music.note",
+            action: { },
+            isLoading: .constant(false),
+            colors: [.green, .darkGreen],
             progress: .constant(.zero)
         )
         AsyncButton(
@@ -52,7 +71,7 @@ struct AsyncButton: View {
             icon: "person",
             action: { },
             isLoading: .constant(false),
-            colors: [.orange, .red], 
+            colors: [.orange, .red],
             progress: .constant(.zero)
         )
         AsyncButton(
@@ -60,7 +79,7 @@ struct AsyncButton: View {
             icon: "person",
             action: { },
             isLoading: .constant(false),
-            colors: [.blue, .green], 
+            colors: [.blue, .green],
             progress: .constant(.zero)
         )
         
@@ -69,23 +88,23 @@ struct AsyncButton: View {
             icon: "person",
             action: { },
             isLoading: .constant(true),
-            colors: [.purple, .pink], 
+            colors: [.purple, .pink],
             progress: .constant(0.5)
         )
         AsyncButton(
-            title: "Share",
-            icon: "person",
+            title: "Add to Spotify",
+            icon: "music.note",
             action: { },
             isLoading: .constant(true),
-            colors: [.orange, .red], 
-            progress: .constant(0.3)
+            colors: [.green, .darkGreen],
+            progress: .constant(0.7)
         )
         AsyncButton(
             title: "Surprise Me",
             icon: "person",
             action: { },
             isLoading: .constant(true),
-            colors: [.blue, .green], 
+            colors: [.blue, .green],
             progress: .constant(0.8)
         )
         AsyncButton(
@@ -95,6 +114,15 @@ struct AsyncButton: View {
             isLoading: .constant(true),
             colors: [.purple, .pink],
             progress: .constant(1.0)
+        )
+        AsyncButton(
+            title: "Share",
+            icon: "person",
+            action: { },
+            isLoading: .constant(true),
+            colors: [.orange, .red],
+            progress: .constant(0.3),
+            showLoadingBar: false
         )
     }
 }

--- a/Vibify/Views/CustomProgressView.swift
+++ b/Vibify/Views/CustomProgressView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct CustomProgressView: View {
     @Binding var progress: Double
     let title: String
+    let showLoadingBar: Bool
     
     var body: some View {
         VStack {
@@ -17,31 +18,36 @@ struct CustomProgressView: View {
                     .foregroundColor(.white)
             }
             
-            ZStack(alignment: .leading) {
-                Rectangle()
-                    .frame(width: loaderSize, height: 20)
-                    .opacity(0.3)
-                    .foregroundColor(.white)
-                
-                Rectangle()
-                    .frame(width: max(CGFloat(progress) * loaderSize, 0), height: 20)
-                    .foregroundColor(.green)
-                    .animation(.snappy, value: progress)
-                
-                Text(String(format: "%.0f%%", min(progress, 1.0) * 100.0))
-                    .font(.caption)
-                    .bold()
-                    .foregroundColor(.white)
-                    .padding(.leading, 4)
-                    .frame(width: loaderSize, alignment: .trailing)
+            if showLoadingBar {
+                ZStack(alignment: .leading) {
+                    Rectangle()
+                        .frame(width: loaderSize, height: 20)
+                        .opacity(0.3)
+                        .foregroundColor(.white)
+                    
+                    Rectangle()
+                        .frame(width: max(CGFloat(progress) * loaderSize, 0), height: 20)
+                        .foregroundColor(.green)
+                        .animation(.snappy, value: progress)
+                    
+                    Text(String(format: "%.0f%%", min(progress, 1.0) * 100.0))
+                        .font(.caption)
+                        .bold()
+                        .foregroundColor(.white)
+                        .padding(.leading, 4)
+                        .frame(width: loaderSize, alignment: .trailing)
+                }
             }
         }
-        .padding()
     }
     
     private let loaderSize: CGFloat = 300
 }
 
 #Preview {
-    CustomProgressView(progress: .constant(0.3), title: "Generating...")
+    CustomProgressView(
+        progress: .constant(0.3),
+        title: "Generating...",
+        showLoadingBar: true
+    )
 }


### PR DESCRIPTION
Adds complete Spotify API integration and UI support during playlist generation. Users can now sign in to their Spotify account, and the Spotify button will change its state once the callback URL code is stored in the keychain and a test call to /v1/me has been made successfully, and the `currentUser` has been set.

Close #43 
Close #44 