### PR TITLE
Fix Playlist Artwork Persistence Across App Launches

### DIFF
--- a/Vibify.xcodeproj/project.pbxproj
+++ b/Vibify.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		5A201B5C2B61E5D600527EA0 /* ServiceStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A201B5B2B61E5D600527EA0 /* ServiceStatusView.swift */; };
 		5A20AE2A2B6DF12000ADA403 /* Prompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A20AE292B6DF12000ADA403 /* Prompts.swift */; };
 		5A2E05472B5228E100B5B8EE /* MusicServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2E05462B5228E100B5B8EE /* MusicServiceType.swift */; };
+		5A37F70A2B799FDA00C60A17 /* UIImage+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A37F7092B799FDA00C60A17 /* UIImage+Ext.swift */; };
 		5A4523742B3FCC530026494C /* SongCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4523732B3FCC530026494C /* SongCardView.swift */; };
 		5A4903392B60A475005688B6 /* PlaylistRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4903382B60A475005688B6 /* PlaylistRowView.swift */; };
 		5A4BFB2B2B4096EF00988D0E /* Date+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4BFB2A2B4096EF00988D0E /* Date+Ext.swift */; };
@@ -95,6 +96,7 @@
 		5A201B5B2B61E5D600527EA0 /* ServiceStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceStatusView.swift; sourceTree = "<group>"; };
 		5A20AE292B6DF12000ADA403 /* Prompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prompts.swift; sourceTree = "<group>"; };
 		5A2E05462B5228E100B5B8EE /* MusicServiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicServiceType.swift; sourceTree = "<group>"; };
+		5A37F7092B799FDA00C60A17 /* UIImage+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Ext.swift"; sourceTree = "<group>"; };
 		5A4523732B3FCC530026494C /* SongCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongCardView.swift; sourceTree = "<group>"; };
 		5A4903382B60A475005688B6 /* PlaylistRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistRowView.swift; sourceTree = "<group>"; };
 		5A4BFB2A2B4096EF00988D0E /* Date+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Ext.swift"; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				5AA3AC702B5CB09400B3BAC7 /* Array+Ext.swift */,
 				5A7C664F2B68824A00B43A32 /* Color+Ext.swift */,
 				5AB6FEC82B69FCCB00367494 /* Data+Ext.swift */,
+				5A37F7092B799FDA00C60A17 /* UIImage+Ext.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -483,6 +486,7 @@
 				5A74F2F82B5CAB9E00042398 /* DalleGenerator.swift in Sources */,
 				5AC0B7D62B45069E00971FF9 /* DBSongMetadata.swift in Sources */,
 				5A0D89562B450ACC003420A8 /* DBPlaylist.swift in Sources */,
+				5A37F70A2B799FDA00C60A17 /* UIImage+Ext.swift in Sources */,
 				5AB6FEC32B69F96C00367494 /* VisionEndpoint.swift in Sources */,
 				5AB6FEC72B69FBAC00367494 /* VisionResponse.swift in Sources */,
 				5A4523742B3FCC530026494C /* SongCardView.swift in Sources */,

--- a/Vibify/Components/UniqueURL.swift
+++ b/Vibify/Components/UniqueURL.swift
@@ -15,7 +15,7 @@ import Foundation
 /// In the `ForEach` loop, use `UniqueURL` instances created from an array of URLs to ensure each item is unique.
 /// Example:
 /// ```
-/// ForEach(playlist.songArtworkURLs.enumerated().map({ UniqueURL(id: $0.offset, url: $0.element) }), id: \.id) { uniqueURL in
+/// ForEach(playlist.songArtworkNames.enumerated().map({ UniqueURL(id: $0.offset, url: $0.element) }), id: \.id) { uniqueURL in
 ///     // Your view code here
 /// }
 /// ```

--- a/Vibify/DatabaseManager.swift
+++ b/Vibify/DatabaseManager.swift
@@ -24,7 +24,7 @@ final class DatabaseManager: DatabaseManaging {
                     t.column("title", .text)
                     t.column("artist", .text)
                     t.column("album", .text)
-                    t.column("artworkURL", .text)
+                    t.column("artworkName", .text)
                     t.column("releaseDate", .date)
                     t.column("genreNames", .text)
                     t.column("isExplicit", .boolean)
@@ -38,7 +38,7 @@ final class DatabaseManager: DatabaseManaging {
                     t.column("id", .text).primaryKey()
                     t.column("createdAt", .date)
                     t.column("title", .text)
-                    t.column("artworkURL", .text)
+                    t.column("artworkName", .text)
                 }
             }
         } catch {
@@ -98,11 +98,11 @@ extension DatabaseManager {
 
 extension DatabaseManager {
     
-    func updatePlaylistArtworkURL(playlistID: String, artworkURL: String) throws {
+    func updatePlaylistArtworkName(playlistID: String, artworkName: String) throws {
         do {
             try dbQueue.write { db in
                 let request = DBPlaylist.filter(DBPlaylist.Columns.playlistID == playlistID)
-                try request.updateAll(db, [DBPlaylist.Columns.artworkURL.set(to: artworkURL)])
+                try request.updateAll(db, [DBPlaylist.Columns.artworkName.set(to: artworkName)])
                 logger.info("Updated artwork URL for playlist with id: \(playlistID)")
             }
         } catch {

--- a/Vibify/DatabaseManaging.swift
+++ b/Vibify/DatabaseManaging.swift
@@ -35,7 +35,7 @@ protocol DatabaseManaging {
     ///
     /// - Parameters:
     ///   - playlistID: A `String` representing the unique identifier of the playlist.
-    ///   - artworkURL: A `String` representing the new artwork URL to be associated with the playlist.
+    ///   - artworkName: A `String` representing the new artwork URL to be associated with the playlist.
     /// - Throws: An error if the artwork URL cannot be updated for the specified playlist.
-    func updatePlaylistArtworkURL(playlistID: String, artworkURL: String) throws
+    func updatePlaylistArtworkName(playlistID: String, artworkName: String) throws
 }

--- a/Vibify/Extensions/UIImage+Ext.swift
+++ b/Vibify/Extensions/UIImage+Ext.swift
@@ -1,0 +1,45 @@
+import Foundation
+import UIKit
+
+extension UIImage {
+
+    /// Returns filename to be saved in DB
+    static func downloadAndSaveImage(from url: URL) async throws -> String {
+        let (data, _) = try await URLSession.shared.data(from: url)
+        guard let image = UIImage(data: data) else {
+            throw NSError(
+                domain: "ImageDownloadError",
+                code: 0,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to create image from downloaded data."
+                ]
+            )
+        }
+
+        guard
+            let documentsDirectory = FileManager.default.urls(
+                for: .documentDirectory,
+                in: .userDomainMask
+            ).first
+        else {
+            throw NSError(
+                domain: "FileSaveError",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "Cannot find documents directory."]
+            )
+        }
+
+        let filename = UUID().uuidString + ".png"
+        let fileURL = documentsDirectory.appendingPathComponent(filename)
+        guard let imageData = image.pngData() else {
+            throw NSError(
+                domain: "ImageConversionError",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to convert image to PNG data."]
+            )
+        }
+
+        try imageData.write(to: fileURL)
+        return filename 
+    }
+}

--- a/Vibify/Mock_DatabaseManager.swift
+++ b/Vibify/Mock_DatabaseManager.swift
@@ -4,7 +4,7 @@ final class Mock_DatabaseManager: DatabaseManaging {
     
     var didCallInsert = false
     var didCallFetchPlaylistHistory = false
-    var didCallUpdatePlaylistArtworkURL = false
+    var didCallUpdatePlaylistArtworkName = false
     
     func insert(playlist: DBPlaylist) throws {
         didCallInsert = true
@@ -16,8 +16,8 @@ final class Mock_DatabaseManager: DatabaseManaging {
         return DBPlaylist.mockPlaylists
     }
     
-    func updatePlaylistArtworkURL(playlistID: String, artworkURL: String) throws {
-        didCallUpdatePlaylistArtworkURL = true
+    func updatePlaylistArtworkName(playlistID: String, artworkName: String) throws {
+        didCallUpdatePlaylistArtworkName = true
         // Mock behavior
     }
 }

--- a/Vibify/Models/DBPlaylist.swift
+++ b/Vibify/Models/DBPlaylist.swift
@@ -3,36 +3,37 @@ import GRDB
 
 struct DBPlaylist: FetchableRecord, MutablePersistableRecord, Identifiable {
     static var databaseTableName = "playlists"
-    
+
     var title: String
     var playlistID: String
     var createdAt: Date
     var songs: [DBSongMetadata]?
-    var artworkURL: String?
-    
+    var artworkName: String?
+
     var songsCount: Int {
         songs?.count ?? 0
     }
-    
+
     var songTitles: [String] {
         songs?.compactMap { $0.title } ?? []
     }
-    
-    var songArtworkURLs: [URL] {
-        songs?.compactMap(\.artworkURL) ?? []
+
+    var songArtworkNames: [URL] {
+        songs?.compactMap(\.artworkName) ?? []
     }
-    
+
     var duration: TimeInterval {
         songs?.reduce(0) { $0 + ($1.duration ?? .zero) } ?? 0
     }
-    
+
     var topTwoGenres: [String] {
-        let genreCounts = songs?.flatMap { $0.genreNames }
+        let genreCounts =
+            songs?.flatMap { $0.genreNames }
             .filter { $0 != "Music" }
             .reduce(into: [:]) { counts, genre in
                 counts[genre, default: 0] += 1
             } ?? [:]
-        
+
         return Array(genreCounts.sorted { $0.value > $1.value }.prefix(2).map { $0.key })
     }
 
@@ -40,66 +41,146 @@ struct DBPlaylist: FetchableRecord, MutablePersistableRecord, Identifiable {
         case title
         case playlistID = "id"
         case createdAt
-        case artworkURL
+        case artworkName
     }
-    
+
     init(
         title: String,
         playlistID: String,
         createdAt: Date,
         songs: [DBSongMetadata]?,
-        artworkURL: String? = nil
+        artworkName: String? = nil
     ) {
         self.title = title
         self.playlistID = playlistID
         self.createdAt = createdAt
         self.songs = songs
-        self.artworkURL = artworkURL
+        self.artworkName = artworkName
     }
-    
+
     init(row: Row) {
         title = row[Columns.title]
         playlistID = row[Columns.playlistID]
         createdAt = row[Columns.createdAt]
-        artworkURL = row[Columns.artworkURL]
+        artworkName = row[Columns.artworkName]
         songs = nil
     }
-    
+
     func encode(to container: inout PersistenceContainer) {
         container[Columns.title] = title
         container[Columns.playlistID] = playlistID
         container[Columns.createdAt] = createdAt
-        container[Columns.artworkURL] = artworkURL
+        container[Columns.artworkName] = artworkName
         // Do not encode 'songs' as it's not part of the database schema
     }
-    
+
     var id: String { playlistID }
+}
+
+extension DBPlaylist {
+
+    func artworkImageURL() throws -> URL? {
+        guard let artworkFilename = artworkName else { return nil }
+
+        let documentsDirectory = try FileManager.default.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+        let fileURL = documentsDirectory.appendingPathComponent(artworkFilename)
+
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            return fileURL
+        }
+
+        return nil
+    }
 }
 
 // MARK: Mock
 
 extension DBPlaylist {
-    
+
     static var mock: DBPlaylist {
-        DBPlaylist(
+        let filename = UUID().uuidString + ".png"
+        saveDataToDocumentsDirectory(filename: filename)
+
+        return DBPlaylist(
             title: "My Playlist",
             playlistID: UUID().uuidString,
             createdAt: Date(),
             songs: DBSongMetadata.mockSongs,
-            artworkURL: Bundle.main.url(forResource: "dalle-sample", withExtension: "png")!.absoluteString
+            artworkName: filename
         )
     }
-    
+
     /// Five unique mocked playlists with their own identifying metadata.
     static var mockPlaylists: [DBPlaylist] {
+        let filename = UUID().uuidString + ".png"
+        saveDataToDocumentsDirectory(filename: filename)
         let playlists = [
-            DBPlaylist(title: "Playlist 1", playlistID: "1", createdAt: Date(), songs: DBSongMetadata.mockSongs, artworkURL: Bundle.main.url(forResource: "dalle-sample", withExtension: "png")!.absoluteString),
-            DBPlaylist(title: "Playlist 2", playlistID: "2", createdAt: Date(), songs: DBSongMetadata.mockSongs, artworkURL: Bundle.main.url(forResource: "dalle-sample", withExtension: "png")!.absoluteString),
-            DBPlaylist(title: "Playlist 3", playlistID: "3", createdAt: Date(), songs: DBSongMetadata.mockSongs, artworkURL: Bundle.main.url(forResource: "dalle-sample", withExtension: "png")!.absoluteString),
-            DBPlaylist(title: "Playlist 4", playlistID: "4", createdAt: Date(), songs: DBSongMetadata.mockSongs, artworkURL: Bundle.main.url(forResource: "dalle-sample", withExtension: "png")!.absoluteString),
-            DBPlaylist(title: "Playlist 5", playlistID: "5", createdAt: Date(), songs: DBSongMetadata.mockSongs, artworkURL: Bundle.main.url(forResource: "dalle-sample", withExtension: "png")!.absoluteString),
+            DBPlaylist(
+                title: "Playlist 1",
+                playlistID: "1",
+                createdAt: Date(),
+                songs: DBSongMetadata.mockSongs,
+                artworkName: filename
+            ),
+            DBPlaylist(
+                title: "Playlist 2",
+                playlistID: "2",
+                createdAt: Date(),
+                songs: DBSongMetadata.mockSongs,
+                artworkName: filename
+            ),
+            DBPlaylist(
+                title: "Playlist 3",
+                playlistID: "3",
+                createdAt: Date(),
+                songs: DBSongMetadata.mockSongs,
+                artworkName: filename
+            ),
+            DBPlaylist(
+                title: "Playlist 4",
+                playlistID: "4",
+                createdAt: Date(),
+                songs: DBSongMetadata.mockSongs,
+                artworkName: filename
+            ),
+            DBPlaylist(
+                title: "Playlist 5",
+                playlistID: "5",
+                createdAt: Date(),
+                songs: DBSongMetadata.mockSongs,
+                artworkName: filename
+            ),
         ]
-        
+
         return playlists
+    }
+
+    /// Saves data to the specified filename within the documents directory.
+    private static func saveDataToDocumentsDirectory(filename: String) {
+        let url = Bundle.main.url(forResource: "dalle-sample", withExtension: "png")!
+        let data = try! Data(contentsOf: url)
+        guard
+            let documentsDirectory = FileManager.default.urls(
+                for: .documentDirectory,
+                in: .userDomainMask
+            ).first
+        else {
+            print("Failed to locate documents directory")
+            return
+        }
+
+        let fileURL = documentsDirectory.appendingPathComponent(filename)
+
+        do {
+            try data.write(to: fileURL)
+            print("File saved: \(fileURL.absoluteString)")
+        } catch {
+            print("Error saving file: \(error)")
+        }
     }
 }

--- a/Vibify/Models/DBSongMetadata.swift
+++ b/Vibify/Models/DBSongMetadata.swift
@@ -4,7 +4,7 @@ import GRDB
 struct DBSongMetadata: Codable, FetchableRecord, MutablePersistableRecord {
 
     enum Columns: String, ColumnExpression {
-        case id, title, artist, album, artworkURL, releaseDate, genreNames, isExplicit,
+        case id, title, artist, album, artworkName, releaseDate, genreNames, isExplicit,
             appleMusicID, previewURL, playlistID, duration
     }
 
@@ -14,7 +14,7 @@ struct DBSongMetadata: Codable, FetchableRecord, MutablePersistableRecord {
     var title: String
     var artist: String
     var album: String
-    var artworkURL: URL?
+    var artworkName: URL?
     var releaseDate: Date?
     var genreNames: [String]
     var isExplicit: Bool
@@ -36,7 +36,7 @@ extension DBSongMetadata {
             title: "Song 1",
             artist: "Artist 1",
             album: "Album 1",
-            artworkURL: image,
+            artworkName: image,
             releaseDate: nil,
             genreNames: ["Genre 1"],
             isExplicit: false,
@@ -56,7 +56,7 @@ extension DBSongMetadata {
                 title: "Song \(index)",
                 artist: "Artist \(index)",
                 album: "Album \(index)",
-                artworkURL: image,
+                artworkName: image,
                 releaseDate: nil,
                 genreNames: ["Genre \(index)"],
                 isExplicit: false,

--- a/Vibify/Screens/PlaylistGeneratorView.swift
+++ b/Vibify/Screens/PlaylistGeneratorView.swift
@@ -182,7 +182,7 @@ private extension PlaylistGeneratorView {
                         )
                     }
                     
-                    if let url = viewModel.playlistArtworkURL {
+                    if let url = viewModel.playlistArtworkName {
                         CachedAsyncImage(url: url)
                             .frame(width: 300, height: 300)
                             .cornerRadius(8)

--- a/Vibify/Screens/PlaylistHistoryView.swift
+++ b/Vibify/Screens/PlaylistHistoryView.swift
@@ -10,15 +10,10 @@ struct PlaylistHistoryView: View {
         NavigationView {
             List(viewModel.playlistHistory) { playlist in
                 ZStack {
-                    if
-                        let urlString = playlist.artworkURL,
-                        let url = URL(string: urlString)
-                    {
-                        CachedAsyncImage(url: url)
-                            .scaledToFit()
-                            .ignoresSafeArea()
-                            .clipped()
-                    }
+                    CachedAsyncImage(url: try? playlist.artworkImageURL())
+                        .scaledToFit()
+                        .ignoresSafeArea()
+                        .clipped()
                     VStack {
                         PlaylistRowView(playlist: playlist)
                             .foregroundStyle(.white)

--- a/Vibify/SongMetaDataParser.swift
+++ b/Vibify/SongMetaDataParser.swift
@@ -123,7 +123,7 @@ final class DBSongMetadataParser {
             
             if let song = response.songs.first {
                 let uniqueID = UUID().uuidString
-                let artworkURL = song.artwork?.url(width: 300, height: 300)
+                let artworkName = song.artwork?.url(width: 300, height: 300)
                 let album = song.albumTitle ?? "Unknown Album"
                 let releaseDate = song.releaseDate
                 let genreNames = song.genreNames
@@ -137,7 +137,7 @@ final class DBSongMetadataParser {
                     title: song.title,
                     artist: song.artistName,
                     album: album,
-                    artworkURL: artworkURL,
+                    artworkName: artworkName,
                     releaseDate: releaseDate,
                     genreNames: genreNames,
                     isExplicit: isExplicit,

--- a/Vibify/Views/PlaylistRowView.swift
+++ b/Vibify/Views/PlaylistRowView.swift
@@ -47,7 +47,7 @@ private extension PlaylistRowView {
     var artworkGrid: some View {
         LazyVGrid(columns: columns, spacing: 8) {
             ForEach(
-                playlist.songArtworkURLs
+                playlist.songArtworkNames
                     .suffix(15)
                     .enumerated()
                     .map { UniqueURL(id: $0.offset, url: $0.element) },

--- a/Vibify/Views/SongCardView.swift
+++ b/Vibify/Views/SongCardView.swift
@@ -11,7 +11,7 @@ struct SongCardView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
-                CachedAsyncImage(url: song.artworkURL)
+                CachedAsyncImage(url: song.artworkName)
                     .frame(width: 60, height: 60)
                     .aspectRatio(contentMode: .fit)
                     .cornerRadius(8)


### PR DESCRIPTION
Close #54 
Implemented a strategy to store and retrieve playlist artwork by filenames instead of absolute URLs. This fix addresses the issue of disappearing artwork on app restarts by saving images in the documents directory and referencing them with filenames in the database, ensuring consistent access across sessions.

- Also renamed `DBPlaylist.artworkURL` to `artworkName` because that's what is being saved now. 
